### PR TITLE
Enalbe usage with Rails 3

### DIFF
--- a/active_record-allow_connection_failure.gemspec
+++ b/active_record-allow_connection_failure.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rake",    "~> 10.0"
+  spec.add_development_dependency "rspec",   "~> 3.0"
 
-  spec.add_runtime_dependency     "rails", ">= 4.2"
+  spec.add_runtime_dependency     "rails", ">= 3.2"
 end

--- a/lib/active_record/allow_connection_failure.rb
+++ b/lib/active_record/allow_connection_failure.rb
@@ -39,17 +39,20 @@ module ActiveRecord
     end
 
     # monkeypatches activerecord/lib/active_record/migration.rb
-    ActiveRecord::Migration::CheckPending.class_eval do
-      def call(env)
-        if ActiveRecord::Base.connected? && connection.supports_migrations?
-          mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
-          if @last_check < mtime
-            ActiveRecord::Migration.check_pending!(connection)
-            @last_check = mtime
-          end
-        end
-        @app.call(env)
-      end
-    end
+     # CheckPending introduced after Rails 4.0
+     if Rails::VERSION::MAJOR >= 4
+       ActiveRecord::Migration::CheckPending.class_eval do
+         def call(env)
+           if ActiveRecord::Base.connected? && connection.supports_migrations?
+             mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
+             if @last_check < mtime
+               ActiveRecord::Migration.check_pending!(connection)
+               @last_check = mtime
+             end
+           end
+           @app.call(env)
+         end
+       end
+     end
   end
 end


### PR DESCRIPTION
* lower `rails` version dependency from 4.2 to 3.2
* skip `CheckPending.class_eval` unless Rails version is >= 4