### PR TITLE
Allow usage with Rails 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,36 @@
 # ActiveRecord::AllowConnectionFailure
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/active_record/allow_connection_failure`. To experiment with that code, run `bin/console` for an interactive prompt.
+This gem monkeypatches methods inside of `ActiveRecord::QueryCache` and
+`ActiveRecord::Migration::CheckPending`.
 
-TODO: Delete this and the text above, and describe your gem
+The intention is to allow a Rails application to boot without first establishing
+a database connection, enabling AR's query caching mechanism, and checking for
+any pending migrations.
 
-## Installation
+In practice, this is useful for situations in which you want to boot your app
+and check e.g. a `/status` endpoint which does not have a database/ORM
+(read: `ActiveRecord`) dependency.
 
-Add this line to your application's Gemfile:
+## Associated `Rails` PR
+
+For additional context, see the associated Rails
+[pull request](https://github.com/rails/rails/issues/22154).
+
+## Usage
+
+Add this gem to your `Gemfile`:
 
 ```ruby
 gem 'active_record-allow_connection_failure'
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install active_record-allow_connection_failure
-
-## Usage
-
-TODO: Write usage instructions here
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/active_record-allow_connection_failure. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
-
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/zipmark/active_record-allow_connection_failure. This project
+is intended to be a safe, welcoming space for collaboration, and contributors
+are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/active_record-allow_connection_failure.gemspec
+++ b/active_record-allow_connection_failure.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rake",    "~> 10.0"
+  spec.add_development_dependency "rspec",   "~> 3.0"
 
-  spec.add_runtime_dependency     "rails", ">= 4.2"
+  spec.add_runtime_dependency     "rails", ">= 3.2"
 end

--- a/lib/active_record/allow_connection_failure.rb
+++ b/lib/active_record/allow_connection_failure.rb
@@ -41,11 +41,9 @@ module ActiveRecord
         end
       end
       
-      module ActiveRecord
-        class Base
-          def self.clear_cache! # :nodoc:
-            connection.schema_cache.clear! if connected?
-          end
+      ActiveRecord::ModelSchema::ClassMethods.module_eval do
+        def clear_cache! # :nodoc:
+          connection.schema_cache.clear! if connected?
         end
       end
     end

--- a/lib/active_record/allow_connection_failure.rb
+++ b/lib/active_record/allow_connection_failure.rb
@@ -6,15 +6,6 @@ module ActiveRecord
   module AllowConnectionFailure
     # monkeypatches activerecord/lib/active_record/query_cache.rb
     if Rails::VERSION::MAJOR == 3
-      module ActiveRecord
-        class Base
-          def self.clear_cache! # :nodoc:
-            puts "Am I connected? #{connected?}"
-            connection.schema_cache.clear! if connected?
-          end
-        end
-      end
-
       ActiveRecord::QueryCache::BodyProxy.class_eval do
         def close
           @target.close if @target.respond_to?(:close)
@@ -46,6 +37,14 @@ module ActiveRecord
               ActiveRecord::Base.connection.disable_query_cache!
             end
             raise e
+          end
+        end
+      end
+      
+      module ActiveRecord
+        class Base
+          def self.clear_cache! # :nodoc:
+            connection.schema_cache.clear! if connected?
           end
         end
       end

--- a/lib/active_record/allow_connection_failure.rb
+++ b/lib/active_record/allow_connection_failure.rb
@@ -39,17 +39,20 @@ module ActiveRecord
     end
 
     # monkeypatches activerecord/lib/active_record/migration.rb
-    ActiveRecord::Migration::CheckPending.class_eval do
-      def call(env)
-        if ActiveRecord::Base.connected? && connection.supports_migrations?
-          mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
-          if @last_check < mtime
-            ActiveRecord::Migration.check_pending!(connection)
-            @last_check = mtime
-          end
-        end
-        @app.call(env)
-      end
-    end
+     # CheckPending introduced after Rails 4.0
+     if Rails::VERSION::MAJOR >= 4
+       ActiveRecord::Migration::CheckPending.class_eval do
+         def call(env)
+           if ActiveRecord::Base.connected? && connection.supports_migrations?
+             mtime = ActiveRecord::Migrator.last_migration.mtime.to_i
+             if @last_check < mtime
+               ActiveRecord::Migration.check_pending!(connection)
+               @last_check = mtime
+             end
+           end
+           @app.call(env)
+         end
+       end
+     end
   end
 end


### PR DESCRIPTION
## Current Behavior

Does not work with Rails 3 due to `gemspec` versioning of the `rails` dependency.

## Why Change?

We'd like to use this gem within `zipmark-service` which is a Rails 3 application.

## Implementation

* lower `rails` version dependency from 4.2 to 3.2 in the `gemspec`
* only evaluate `ActiveRecord::Migration::CheckPending.class_eval` block if Rails version is >= 4